### PR TITLE
dongjiang, fix static check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Static Check
         run: staticcheck -tests=false ./...
 
-      - name: License Header Check
-        run: make check-license-header
-
   lint:
     runs-on: ubuntu-latest
     needs: detect-noop

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,7 +57,7 @@ jobs:
         run: go install honnef.co/go/tools/cmd/staticcheck@2022.1
 
       - name: Static Check
-        run: staticcheck ./...
+        run: staticcheck -tests=false ./...
 
       - name: License Header Check
         run: make check-license-header
@@ -94,7 +94,7 @@ jobs:
         with:
           version: ${{ env.GOLANGCI_VERSION }}
 
-  check-diff:
+  unittest:
     runs-on: aliyun
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
@@ -110,11 +110,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-
       - name: Install StaticCheck
         run: go install honnef.co/go/tools/cmd/staticcheck@2022.1
 
@@ -125,17 +120,5 @@ jobs:
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
 
-      - name: Check code formatting
-        run: go install golang.org/x/tools/cmd/goimports && make fmt
-
-      - name: Run cross-build
-        run: make cross-build
-
-      - name: Check Diff
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
-          export PATH=$(pwd)/bin/:$PATH
-          make check-diff
-              
-      - name: Cleanup binary
-        run: make build-cleanup
+      - name: unittest
+        run: go test ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ linters:
   enable:
     - gosimple
     - ineffassign
-    - revive
     - structcheck
     - typecheck
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - dupl
+    - godot
+    - goimports
+    - gosimple
+    - ineffassign
+    - misspell
+    - revive
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,8 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
-    - dupl
-    - godot
-    - goimports
     - gosimple
     - ineffassign
-    - misspell
     - revive
     - structcheck
     - typecheck

--- a/pkg/cache/lfu.go
+++ b/pkg/cache/lfu.go
@@ -195,7 +195,7 @@ func (c *LFUPlugin) evict(count int) {
 		if entry == nil {
 			return
 		} else {
-			for item, _ := range entry.Value.(*freqEntry).items {
+			for item := range entry.Value.(*freqEntry).items {
 				if i >= count {
 					return
 				}

--- a/pkg/cache/lfu_test.go
+++ b/pkg/cache/lfu_test.go
@@ -189,6 +189,7 @@ func TestLFUGetIFPresent(t *testing.T) {
 
 	v, err := cache.GetIFPresent("key")
 	assert.Equal(err, ErrCacheKeyNotFind)
+	assert.Equal(v, nil)
 
 	time.Sleep(20 * time.Millisecond) //时间够长，case稳定
 

--- a/pkg/cache/lru_test.go
+++ b/pkg/cache/lru_test.go
@@ -201,6 +201,7 @@ func TestLRUGetIFPresent(t *testing.T) {
 
 	v, err := cache.GetIFPresent("key")
 	assert.Equal(err, ErrCacheKeyNotFind)
+	assert.Equal(v, nil)
 
 	time.Sleep(20 * time.Millisecond) //时间够长，case稳定
 

--- a/pkg/config/loader/loader.go
+++ b/pkg/config/loader/loader.go
@@ -22,7 +22,6 @@ package configloader
 import (
 	"github.com/kubeservice-stack/common/pkg/config"
 	"github.com/kubeservice-stack/common/pkg/logger"
-	"github.com/kubeservice-stack/common/pkg/metrics"
 )
 
 func LoadConfig(cfgPath string) (err error) {

--- a/pkg/config/logger.go
+++ b/pkg/config/logger.go
@@ -34,7 +34,7 @@ type Logging struct {
 	Level      string `toml:"level" json:"level" env:"LOGGING_LEVEL"`                //打印日志等级
 	MaxSize    uint16 `toml:"maxsize" json:"maxsize" env:"LOGGING_MAXSIZE"`          //单日志尺寸
 	MaxBackups uint16 `toml:"maxbackups" json:"maxbackups" env:"LOGGING_MAXBACKUPS"` //日志备份数
-	MaxAge     uint16 `toml:"maxage"json:"maxage" env:"LOGGING_MAXAGE"`              //留旧日志文件的最大天数
+	MaxAge     uint16 `toml:"maxage" json:"maxage" env:"LOGGING_MAXAGE"`             //留旧日志文件的最大天数
 }
 
 func (l Logging) TOML() string {

--- a/pkg/config/temporary.go
+++ b/pkg/config/temporary.go
@@ -24,8 +24,8 @@ import (
 type Temporary struct {
 	MaxBufferSize int64  `toml:"max_buffer_size" json:"max_buffer_size" env:"TEMPORARY_MAX_BUFFER_SIZE"` // 最大使用内存空间, 超过时则转化成文件
 	FileDir       string `toml:"file_dir" json:"file_dir" env:"TEMPORARY_FILE_DIR"`                      // 临时文件目录
-	FilePattern   string `toml:"file_pattern" json:"file_pattern" env "TEMPORARY_FILE_PATTERN"`          // 临时文件名格式
-	MaxUploadSize int64  `toml:"max_upload_size" json:"max_upload_size" env "TEMPORARY_MAX_UPLOAD_SIZE"` // 最大上传文件大小
+	FilePattern   string `toml:"file_pattern" json:"file_pattern" env:"TEMPORARY_FILE_PATTERN"`          // 临时文件名格式
+	MaxUploadSize int64  `toml:"max_upload_size" json:"max_upload_size" env:"TEMPORARY_MAX_UPLOAD_SIZE"` // 最大上传文件大小
 }
 
 func (l Temporary) TOML() string {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeservice-stack/common/pkg/config"
 	"github.com/kubeservice-stack/common/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/uber-go/tally"
 	promreporter "github.com/uber-go/tally/prometheus"
 )
@@ -44,14 +45,14 @@ var DefaultTallyScope *TallyScope
 func NewTallyScope(cfg *config.Metrics) *TallyScope {
 	if cfg.EnableGoRuntimeMetrics {
 		onceEnable.Do(func() {
-			DefaultRegistry().Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-			DefaultRegistry().Register(prometheus.NewGoCollector())
+			DefaultRegistry().Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+			DefaultRegistry().Register(collectors.NewGoCollector())
 			prometheusLogger.Info("go runtime metrics is exported")
 		})
 	} else {
 		onceEnable.Do(func() {
-			DefaultRegistry().Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-			DefaultRegistry().Unregister(prometheus.NewGoCollector())
+			DefaultRegistry().Unregister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+			DefaultRegistry().Unregister(collectors.NewGoCollector())
 		})
 	}
 

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -69,7 +69,7 @@ func TestLfQueueConsistency(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	q := New(2)
-	go func() {
+	go func(t *testing.T) {
 		i := 0
 		seen := make(map[string]string)
 		for {
@@ -95,7 +95,7 @@ func TestLfQueueConsistency(t *testing.T) {
 				return
 			}
 		}
-	}()
+	}(t)
 
 	for j := 0; j < c; j++ {
 		jj := j

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -87,6 +87,8 @@ func TestLfQueueConsistency(t *testing.T) {
 			_, present := seen[s]
 			if present {
 				t.FailNow()
+				wg.Done()
+				return
 			}
 			seen[s] = s
 

--- a/pkg/utils/file_test.go
+++ b/pkg/utils/file_test.go
@@ -42,6 +42,7 @@ func TestSearchFile(t *testing.T) {
 	t.Log(path)
 
 	path, err = SearchFile(noExistedFile, ".")
+	t.Log(path)
 
 	assert.NotNil(err, "没有发生错误")
 }

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -8,7 +8,7 @@ import (
 
 func Keys(maps map[string]interface{}) []string {
 	var keys []string
-	for k, _ := range maps {
+	for k := range maps {
 		keys = append(keys, k)
 	}
 	return keys
@@ -26,7 +26,7 @@ func Sort(maps map[string]string) map[string]string {
 	ret := make(map[string]string)
 
 	priorities := make([]string, 0)
-	for key, _ := range maps {
+	for key := range maps {
 		priorities = append(priorities, key)
 	}
 	sort.Strings(priorities)
@@ -61,8 +61,7 @@ func Merge(mapsA map[string]string, mapsB map[string]string) (map[string]string,
 	if mapsA == nil && mapsB == nil {
 		return nil, nil
 	}
-	ret := make(map[string]string)
-	ret = mapsA
+	ret := mapsA
 	if mapsB == nil {
 		return ret, nil
 	}

--- a/pkg/utils/map_test.go
+++ b/pkg/utils/map_test.go
@@ -59,8 +59,7 @@ func TestUtil_MapSort(t *testing.T) {
 
 func TestUtil_MapSortKey(t *testing.T) {
 	assert := assert.New(t)
-	maps := make([]string, 0)
-	maps = []string{"1", "10", "9"}
+	maps := []string{"1", "10", "9"}
 
 	vs := SortKey(maps)
 

--- a/pkg/utils/slice.go
+++ b/pkg/utils/slice.go
@@ -43,7 +43,7 @@ func InSliceIfaceToLower(v string, sl interface{}) (bool, error) {
 	alSArr := ToStrings(slArr)
 
 	for _, vv := range alSArr {
-		if strings.ToLower(vv) == strings.ToLower(v) {
+		if strings.EqualFold(v, vv) {
 			return true, nil
 		}
 	}
@@ -141,7 +141,7 @@ func ToStringDict(items []interface{}, key string) ([]string, error) {
 	for _, item := range items {
 		it, ok := item.(map[string]interface{})
 		if !ok {
-			return nil, errors.New("interface{} to map[string]string err!")
+			return nil, errors.New("interface{} to map[string]string err")
 		}
 		ret = append(ret, it[key].(string))
 	}

--- a/pkg/utils/timestamp_test.go
+++ b/pkg/utils/timestamp_test.go
@@ -90,6 +90,9 @@ func TestTimstamp_MarshalReflexivity(t *testing.T) {
 		}
 		var got Timestamp
 		err = json.Unmarshal(data, &got)
+		if err != nil {
+			t.Errorf("%s: Marshal err=%v", tc.desc, err)
+		}
 		if !got.Equal(tc.data) {
 			t.Errorf("%s: %+v != %+v", tc.desc, got, data)
 		}
@@ -171,6 +174,9 @@ func TestWrappedTimstamp_MarshalReflexivity(t *testing.T) {
 		}
 		var got WrappedTimestamp
 		err = json.Unmarshal(bytes, &got)
+		if err != nil {
+			t.Errorf("%s: Marshal err=%v", tc.desc, err)
+		}
 		if !got.Time.Equal(tc.data.Time) {
 			t.Errorf("%s: %+v != %+v", tc.desc, got, tc.data)
 		}


### PR DESCRIPTION
##  Fix Static Check
```
Run staticcheck ./...
Error: pkg/cache/lfu.go:19[8](https://github.com/kubeservice-stack/common/actions/runs/3521434984/jobs/5903288433#step:6:9):14: unnecessary assignment to the blank identifier (S1005)
Error: pkg/cache/lfu_test.go:1[9](https://github.com/kubeservice-stack/common/actions/runs/3521434984/jobs/5903288433#step:6:10)0:2: this value of v is never used (SA4006)
Error: pkg/cache/lru_test.go:202:2: this value of v is never used (SA4006)
Error: pkg/config/loader/loader.go:25:2: "github.com/kubeservice-stack/common/pkg/metrics" imported but not used (compile)
Error: pkg/metrics/metrics.go:47:31: prometheus.NewProcessCollector is deprecated: Use collectors.NewProcessCollector instead.  (SA[10](https://github.com/kubeservice-stack/common/actions/runs/3521434984/jobs/5903288433#step:6:11)19)
Error: pkg/metrics/metrics.go:48:31: prometheus.NewGoCollector is deprecated: Use collectors.NewGoCollector instead.  (SA1019)
Error: pkg/metrics/metrics.go:53:33: prometheus.NewProcessCollector is deprecated: Use collectors.NewProcessCollector instead.  (SA1019)
Error: pkg/metrics/metrics.go:54:33: prometheus.NewGoCollector is deprecated: Use collectors.NewGoCollector instead.  (SA1019)
Error: pkg/queue/queue_test.go:72:2: the goroutine calls T.FailNow, which must be called in the same goroutine as the test (SA2002)
Error: 	pkg/queue/queue_test.go:89:5: call to T.FailNow
Error: pkg/utils/file_test.go:44:2: this value of path is never used (SA4006)
Error: pkg/utils/map.go:[11](https://github.com/kubeservice-stack/common/actions/runs/3521434984/jobs/5903288433#step:6:12):9: unnecessary assignment to the blank identifier (S1005)
Error: pkg/utils/map.go:29:11: unnecessary assignment to the blank identifier (S1005)
Error: pkg/utils/map.go:64:2: this value of ret is never used (SA4006)
Error: pkg/utils/map_test.go:62:2: this value of maps is never used (SA4006)
Error: pkg/utils/slice.go:46:6: should use strings.EqualFold instead (SA6005)
Error: pkg/utils/slice.go:[14](https://github.com/kubeservice-stack/common/actions/runs/3521434984/jobs/5903288433#step:6:15)4:16: error strings should not end with punctuation or newlines (ST1005)
Error: pkg/utils/timestamp_test.go:92:3: this value of err is never used (SA4006)
Error: pkg/utils/timestamp_test.go:[17](https://github.com/kubeservice-stack/common/actions/runs/3521434984/jobs/5903288433#step:6:18)3:3: this value of err is never used (SA4006)
```