### PR TITLE
[fix] Performance bug

### DIFF
--- a/pkg/codec/mcpack/decode.go
+++ b/pkg/codec/mcpack/decode.go
@@ -92,7 +92,7 @@ func (d *decodeState) indirect(v reflect.Value, decodingNull bool) (Unmarshaler,
 	// If v is a named type and is addressable
 	// start with its address, so that is the type has pointer
 	// methods, we find them
-	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+	if v.CanAddr() && v.Kind() != reflect.Ptr && v.Type().Name() != "" {
 		v = v.Addr()
 	}
 


### PR DESCRIPTION
## pprof bad case
```
  Total:           0       50ms (flat, cum)  1.85%
     90            .          .           		return nil, reflect.Value{} 
     91            .          .           	} 
     92            .          .           	// If v is a named type and is addressable 
     93            .          .           	// start with its address, so that is the type has pointer 
     94            .          .           	// methods, we find them 
     95            .       40ms           	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() { 
     96            .       10ms           		v = v.Addr() 
     97            .          .           	} 
     98            .          .            
     99            .          .           	for { 
    100            .          .           		// Load value from interface, but only if the result will be 
    101            .          .           		// usefully addressable 

```

fix bug