### PR TITLE
[feat] add strings2bytes and bytes2strings function

### DIFF
--- a/pkg/utils/slice_test.go
+++ b/pkg/utils/slice_test.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"log"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,19 +33,13 @@ func TestUtil_ToStringDict(t *testing.T) {
 	assert.Nil(err, "is not err")
 
 	da, ok := data["data"]
-	if !ok {
-		log.Println("WhiteListUrl resp is not find key data!")
-	}
+	assert.True(ok)
 
 	plist, err := ToSlice(da)
-	if err != nil {
-		log.Println("WhiteListUrl interface to []interface err!")
-	}
+	assert.Nil(err)
 
-	log.Println(plist)
 	aa, err := ToStringDict(plist, "phone")
 	assert.Nil(err, "is not err")
-	log.Println(aa)
 	assert.NotNil(aa, "is not err")
 }
 

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -66,7 +66,7 @@ func Substr(str string, start, length int) string {
 	return string(rs[start:end])
 }
 
-func Strings2Bytes(s string) (b []byte) {
+func String2Bytes(s string) (b []byte) {
 	bs := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	ss := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bs.Data = ss.Data
@@ -75,7 +75,7 @@ func Strings2Bytes(s string) (b []byte) {
 	return b
 }
 
-func Bytes2Strings(b []byte) (s string) {
+func Bytes2String(b []byte) (s string) {
 	s = *(*string)(unsafe.Pointer(&b))
 	return s
 }

--- a/pkg/utils/strings.go
+++ b/pkg/utils/strings.go
@@ -17,7 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"reflect"
 	"strings"
+	"unsafe"
 )
 
 func GetBetweenStr(str, start, end string) string {
@@ -62,4 +64,18 @@ func Substr(str string, start, length int) string {
 	}
 
 	return string(rs[start:end])
+}
+
+func Strings2Bytes(s string) (b []byte) {
+	bs := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	ss := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bs.Data = ss.Data
+	bs.Len = ss.Len
+	bs.Cap = ss.Len
+	return b
+}
+
+func Bytes2Strings(b []byte) (s string) {
+	s = *(*string)(unsafe.Pointer(&b))
+	return s
 }

--- a/pkg/utils/strings_benchmark_test.go
+++ b/pkg/utils/strings_benchmark_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 The KubeService-Stack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils_test
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/kubeservice-stack/common/pkg/utils"
+)
+
+func GenerateRandomString(n int) (string, error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+	ret := make([]byte, n)
+	for i := 0; i < n; i++ {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		if err != nil {
+			return "", err
+		}
+		ret[i] = letters[num.Int64()]
+	}
+
+	return string(ret), nil
+}
+
+func BenchmarkStrings2Bytes(b *testing.B) {
+	b.Helper()
+	str, _ := GenerateRandomString(256)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = utils.Strings2Bytes(str)
+	}
+}
+
+func BenchmarkClassic2Bytes(b *testing.B) {
+	b.Helper()
+	str, _ := GenerateRandomString(256)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = []byte(str)
+	}
+}
+
+func GenerateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func BenchmarkBytes2Strings(b *testing.B) {
+	b.Helper()
+	by, _ := GenerateRandomBytes(256)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = utils.Bytes2Strings(by)
+	}
+}
+
+func BenchmarkClassic2Strings(b *testing.B) {
+	b.Helper()
+	by, _ := GenerateRandomBytes(256)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = string(by)
+	}
+}

--- a/pkg/utils/strings_benchmark_test.go
+++ b/pkg/utils/strings_benchmark_test.go
@@ -44,7 +44,7 @@ func BenchmarkStrings2Bytes(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = utils.Strings2Bytes(str)
+		_ = utils.String2Bytes(str)
 	}
 }
 
@@ -74,7 +74,7 @@ func BenchmarkBytes2Strings(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = utils.Bytes2Strings(by)
+		_ = utils.Bytes2String(by)
 	}
 }
 

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -80,37 +80,37 @@ func Test_SubStr(t *testing.T) {
 
 func Test_Strings2Bytes(t *testing.T) {
 	assert := assert.New(t)
-	b := Strings2Bytes("adfbd中国 adsf")
+	b := String2Bytes("adfbd中国 adsf")
 	assert.Equal(b, []byte{0x61, 0x64, 0x66, 0x62, 0x64, 0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0x20, 0x61, 0x64, 0x73, 0x66})
 
-	b = Strings2Bytes("")
+	b = String2Bytes("")
 	assert.Equal(b, []byte(nil))
 
 	s := new(string)
 	*s = "aaa"
-	b = Strings2Bytes(*s)
+	b = String2Bytes(*s)
 	assert.Equal(b, []byte{0x61, 0x61, 0x61})
 
 	*s = ""
-	b = Strings2Bytes(*s)
+	b = String2Bytes(*s)
 	assert.Equal(b, []byte(nil))
 }
 
 func Test_Bytes2Strings(t *testing.T) {
 	assert := assert.New(t)
-	s := Bytes2Strings([]byte{0x61, 0x64, 0x66, 0x62, 0x64, 0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0x20, 0x61, 0x64, 0x73, 0x66})
+	s := Bytes2String([]byte{0x61, 0x64, 0x66, 0x62, 0x64, 0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0x20, 0x61, 0x64, 0x73, 0x66})
 	assert.Equal(s, "adfbd中国 adsf")
 
 	b := new([]byte)
 	*b = nil
-	s = Bytes2Strings(*b)
+	s = Bytes2String(*b)
 	assert.Equal(s, "")
 
 	*b = []byte{}
-	s = Bytes2Strings(*b)
+	s = Bytes2String(*b)
 	assert.Equal(s, "")
 
 	*b = []byte("!$_&-  éè  ;∞¥₤€")
-	s = Bytes2Strings(*b)
+	s = Bytes2String(*b)
 	assert.Equal(s, "!$_&-  éè  ;∞¥₤€")
 }

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -78,10 +78,39 @@ func Test_SubStr(t *testing.T) {
 	assert.Equal(substr, "dfddwe", "is true")
 }
 
-//func Test_interface(t *testing.T) {
-//	assert := assert.New(t)
+func Test_Strings2Bytes(t *testing.T) {
+	assert := assert.New(t)
+	b := Strings2Bytes("adfbd中国 adsf")
+	assert.Equal(b, []byte{0x61, 0x64, 0x66, 0x62, 0x64, 0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0x20, 0x61, 0x64, 0x73, 0x66})
 
-//	var tmp interface{}
-//	tmp = append(tmp, "aaa")
+	b = Strings2Bytes("")
+	assert.Equal(b, []byte(nil))
 
-//}
+	s := new(string)
+	*s = "aaa"
+	b = Strings2Bytes(*s)
+	assert.Equal(b, []byte{0x61, 0x61, 0x61})
+
+	*s = ""
+	b = Strings2Bytes(*s)
+	assert.Equal(b, []byte(nil))
+}
+
+func Test_Bytes2Strings(t *testing.T) {
+	assert := assert.New(t)
+	s := Bytes2Strings([]byte{0x61, 0x64, 0x66, 0x62, 0x64, 0xe4, 0xb8, 0xad, 0xe5, 0x9b, 0xbd, 0x20, 0x61, 0x64, 0x73, 0x66})
+	assert.Equal(s, "adfbd中国 adsf")
+
+	b := new([]byte)
+	*b = nil
+	s = Bytes2Strings(*b)
+	assert.Equal(s, "")
+
+	*b = []byte{}
+	s = Bytes2Strings(*b)
+	assert.Equal(s, "")
+
+	*b = []byte("!$_&-  éè  ;∞¥₤€")
+	s = Bytes2Strings(*b)
+	assert.Equal(s, "!$_&-  éè  ;∞¥₤€")
+}


### PR DESCRIPTION
### What type of PR is this?
/kind feature

- [x] Unittest
- [x] Coverage 80%+
- [x] Build Success

### What this PR does / why we need it:
1.  Add strings2bytes and bytes2strings function with zero-copy

### Benchmark case

`strings2bytes(str)` compare with `[]byte(str)`, `bytes2strings(b)` compare wit `string(b)`  benchmark case

```
goos: darwin
goarch: amd64
pkg: github.com/kubeservice-stack/common/pkg/utils
cpu: VirtualApple @ 2.50GHz
BenchmarkStrings2Bytes-8     	1000000000	         0.2912 ns/op	       0 B/op	       0 allocs/op
BenchmarkClassic2Bytes-8     	29235105	        39.44 ns/op	     256 B/op	       1 allocs/op
BenchmarkBytes2Strings-8     	1000000000	         0.2885 ns/op	       0 B/op	       0 allocs/op
BenchmarkClassic2Strings-8   	32681666	        36.58 ns/op	     256 B/op	       1 allocs/op
PASS
ok  	github.com/kubeservice-stack/common/pkg/utils	3.546s
```
